### PR TITLE
Remove the --username flag, replace it with a new branch selection algorithm.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,6 @@ It accepts the following command-line flags:
 * `--debug`/`-d`: Used for debugging `git-tree`'s commit selection. Displays the
   commits that `git-tree` is trying to show as well as the inclusion/exclusions
   arguments it is passing to `git log`.
-* `--username`/`-u`: Specifies a username to look for to determine whether a
-  remote repository is owned by the user invoking `git-tree`. `git-tree` shows
-  all branches in this repository, rather than only branches corresponding to
-  local branches.
 
 Additionally, any remaining arguments after a `--` are passed through to `git
 log`, allowing the user to set up their own formatting options.
@@ -23,7 +19,7 @@ log`, allowing the user to set up their own formatting options.
 For example, I have the following alias in my `.bashrc` to invoke `git-tree`:
 
 ```
-alias git-tree='git-tree -u jrvanwhy -- --format="%C(auto)%h %d %<(50,trunc)%s"'
+alias git-tree='git-tree -- --format="%C(auto)%h %d %<(50,trunc)%s"'
 ```
 
 This produces output similar to the following (albeit colorized by default,

--- a/git-tree/Cargo.toml
+++ b/git-tree/Cargo.toml
@@ -21,7 +21,7 @@ edition = "2018"
 keywords = ["git"]
 license = "Apache-2.0"
 name = "git-tree"
-version = "1.0.0"
+version = "2.0.0"
 
 [[bin]]
 name = "git-tree"

--- a/git-tree/main.rs
+++ b/git-tree/main.rs
@@ -15,8 +15,7 @@
 /// Computes and returns "interesting" commits -- the commits we would like to
 /// show the history graph for.
 fn get_interesting_commits(repository: &git2::Repository,
-                           debug: bool,
-                           username: Option<&str>) -> fnv::FnvHashSet<git2::Oid> {
+                           debug: bool) -> fnv::FnvHashSet<git2::Oid> {
     let mut interesting_commits = fnv::FnvHashSet::default();
 
     // HEAD is always interesting.
@@ -26,73 +25,48 @@ fn get_interesting_commits(repository: &git2::Repository,
                                          .expect("HEAD is not a commit")
                                          .id());
 
-    // Cache storing whether or not a given remote is interesting (i.e. whether
-    // it contains my username).
-    let mut remote_cache = fnv::FnvHashMap::default();
+    // Utility function to add branch to interesting_commits.
+    let mut add_branch = |branch: git2::Branch| interesting_commits.insert(
+        branch.get()
+              .peel_to_commit()
+              .expect("Unable to resolve branch into commit")
+              .id()
+    );
+
+    // Names of all local branches.
+    let mut local_branch_names = fnv::FnvHashSet::default();
+
+    // All remote branches.
+    let mut remote_branches = Vec::new();
 
     // Iterate through all branches. At each step, repository.branches gives us
     // the branch object as well as the type of branch (local or remote).
     for (branch, branch_type) in repository.branches(None)
                                            .expect("Failed to identify branches")
                                            .map(|r| r.expect("Failed to open branch")) {
-        // Utility function to add branch to interesting_commits.
-        let mut add_branch = || interesting_commits.insert(
-            branch.get()
-                  .peel_to_commit()
-                  .expect("Unable to resolve branch into commit")
-                  .id()
-        );
-
         // All local branches are assumed to be interesting.
         if branch_type == git2::BranchType::Local {
-            add_branch();
+            local_branch_names.insert(branch.name_bytes().expect("No local branch name").to_vec());
+            add_branch(branch);
             continue;
         }
 
         // The branch is remote; identify the remote name and the remote's
         // branch name
-        let (remote_name, base_name) = {
+        let (_remote_name, base_name) = {
             let mut parts_iter = branch.name_bytes().expect("No remote branch name")
                                                     .splitn(2, |&b| b == b'/');
             (parts_iter.next().expect("Branch name missing remote"),
              parts_iter.next().expect("Branch name missing base"))
         };
 
-        // Assume "master" is interesting.
-        if base_name == b"master" {
-            add_branch();
-            continue;
-        }
+        remote_branches.push((base_name.to_vec(), branch));
+    }
 
-        // At this point, we assume a branch is interesting iff it is in a
-        // repository containing my username.
-        // Unwrap username. If username was provided, then this branch is not
-        // interesting so skip it.
-        let username = match username {
-            None => continue,
-            Some(username) => username,
-        };
-
-        if let Some(&is_interesting) = remote_cache.get(remote_name) {
-            // Cache hit
-            if is_interesting {
-                add_branch();
-            }
-            continue;
-        }
-
-        // Cache miss, need to scan the remote's URL to identify if it's
-        // interesting.
-        let is_interesting = repository.find_remote(std::str::from_utf8(remote_name)
-                                                    .expect("Non-UTF-8 remote"))
-                                       .expect("Known remote missing")
-                                       .url()
-                                       .expect("non-utf8 remote url")
-                                       .contains(username);
-        remote_cache.insert(remote_name.to_vec(), is_interesting);
-        if is_interesting {
-            add_branch();
-        }
+    // Iterate through all remote branches. Remote branches that have the same
+    // name as local branches are considered interesting.
+    for (name, branch) in remote_branches {
+        if local_branch_names.contains(&name) { add_branch(branch); }
     }
 
     if debug {
@@ -108,14 +82,12 @@ fn main() {
     let cmdline_matches = clap::App::new("git-tree")
         .arg(clap::Arg::with_name("debug").long("debug").short("d"))
         .arg(clap::Arg::with_name("git_params").last(true).multiple(true))
-        .arg(clap::Arg::with_name("username").long("username").short("u").takes_value(true))
         .get_matches();
 
     let repository = git2::Repository::open_from_env()
         .expect("Failed to open repository: is . a git repo?");
     let interesting_commits = get_interesting_commits(&repository,
-                                                      cmdline_matches.is_present("debug"),
-                                                      cmdline_matches.value_of("username"));
+                                                      cmdline_matches.is_present("debug"));
 
     // Transform the set of commits we want to show (interesting commits) into
     // the arguments we need to pass to git log to show them.


### PR DESCRIPTION
Previously, gitxl included all branches from remotes whose URL contains the given username. The new algorithm shows all branches whose name matches a local branch. This is simpler to configure, and less finicky. The downside is that to show a remote branch you need to create a local tracking branch, but I haven't found that to be a significant issue.

I also increased the version number to 2.0 because removing a command line flag is a breaking change.