### PR TITLE
Add a GitHub Actions workflow that confirms that git-tree builds.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,40 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: ci
+on: pull_request
+
+jobs:
+  build:
+    # Normally I would pin to a particular Ubuntu version to avoid breakage when
+    # `ubuntu-latest` is updated to a newer release, but that only works for
+    # projects that are developed sufficiently heavily. I don't anticipate doing
+    # much more development in this repository so this workflow would probably
+    # become outdated, so just point at ubuntu-latest. This is a pretty simple
+    # project so I don't anticipate breakage regardless.
+    runs-on: ubuntu-latest
+
+    steps:
+      # Clones a single commit from the repository. The commit cloned is a merge
+      # commit between the PR's target branch and the PR's source. We'll later
+      # add another commit (the pre-merge target branch) to the repository.
+      - name: Clone repository
+        uses: actions/checkout@v2.3.1
+
+      # Attempts to build git-tree. git-tree depends on gitloggraph so this will
+      # test both crates.
+      - name: Build
+        run: |
+          cd "${GITHUB_WORKSPACE}/git-tree"
+          cargo build --release


### PR DESCRIPTION
Now I have a CI system, even if I don't have much to test.